### PR TITLE
Do not HTTPS redirect Let'sEncrypt ACME challenge

### DIFF
--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -246,7 +246,19 @@ server {
 	listen [::]:80 {{ $default_server }};
 	{{ end }}
 	access_log /var/log/nginx/access.log vhost;
-	return 301 https://$host$request_uri;
+	
+	# Do not HTTPS redirect Let'sEncrypt ACME challenge
+	location /.well-known/acme-challenge/ {
+		auth_basic off;
+		allow all;
+		root /usr/share/nginx/html;
+		try_files $uri =404;
+		break;
+	}
+	
+	location / {
+		return 301 https://$host$request_uri;
+	}
 }
 {{ end }}
 


### PR DESCRIPTION
The auto renewal of Let'sEncrypt certificates fails due to the HTTPS redirect of the ACME challenge.

This workaround resolves the issue:
https://gist.github.com/codekitchen/2c519eb7572002afab6a5f979cd42913#file-letsencrypt-diff

Found through this comment:
https://github.com/JrCs/docker-letsencrypt-nginx-proxy-companion/issues/526#issuecomment-476253642